### PR TITLE
Fix version number in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: "Merge"
-      uses: "nucleos/auto-merge-action@1"
+      uses: "nucleos/auto-merge-action@1.0.0"
       env:
         "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
## Subject

The example workflow does not work, as it requires the version to be fully fleshed out, i.e. `@1.0.0`. With `@1` as version, you only get an error message:

<img width="707" alt="Merge pull request #96 from ampproject_add_automerge-prs · ampproject_amp-t  2021-03-13 at 10 27 15 AM" src="https://user-images.githubusercontent.com/83631/111027384-da6a0f80-83e7-11eb-82bd-76e31728e94a.png">